### PR TITLE
Add OCP 4.15 entry

### DIFF
--- a/kubeOpenShiftVersionMap.yaml
+++ b/kubeOpenShiftVersionMap.yaml
@@ -1,5 +1,7 @@
 # Based on https://access.redhat.com/solutions/4870701
 versions:
+- kube-version: "1.28"
+  ocp-version: "4.15"
 - kube-version: "1.27"
   ocp-version: "4.14"
 - kube-version: "1.26"


### PR DESCRIPTION
Adds support for OCP 4.15 which is GA as of yesterday.

Chart Verifier will be updated after this merges.